### PR TITLE
Use vagrant for e2e tests and enhance them to check for auth file removal

### DIFF
--- a/.github/github-actions-setup
+++ b/.github/github-actions-setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
+
+apt-get update
+apt-get install -y vagrant virtualbox

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,13 +14,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Cache Vagrant boxes
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('test/Vagrantfile') }}
       - name: Setup golang
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
-      - name: Build the credential provider binary
-        run: make
-      - name: Setup CRI-O and Kubernetes
-        run: sudo -E test/e2e-setup
-      - name: Run the tests
-        run: test/e2e-run
+      - name: Setup GitHub actions
+        run: sudo .github/github-actions-setup
+      - name: Run the e2e tests
+        run: make e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
+test/.vagrant
 vendor

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ $(BUILD_DIR)/$(PROJECT): $(BUILD_DIR) $(BUILD_FILES)
 .PHONY: clean
 clean: ## Clean the build directory
 	rm -rf $(BUILD_DIR)
+	cd test && vagrant destroy -f
 
 .PHONY: test
 test: $(BUILD_DIR) ## Run the unit tests
@@ -103,3 +104,8 @@ shellcheck: shellfiles $(SHELLCHECK) ## Run shellcheck on all shell files
 		-P test/registry \
 		-x \
 		$(SHELLFILES)
+
+.PHONY: e2e
+e2e: $(BUILD_DIR)/$(PROJECT) ## Run the e2e tests
+	cd test && vagrant up
+	test/vagrant-run test/e2e-run

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrant box for testing
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2204"
+  memory = 6144
+  cpus = 4
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.provider :libvirt do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.synced_folder "../", "/vagrant"
+
+  config.vm.provision "setup", type: "shell", inline: "/vagrant/test/e2e-setup", run: "once"
+end

--- a/test/e2e-run
+++ b/test/e2e-run
@@ -4,11 +4,27 @@ set -euox pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR"
 
+# Prepare registries.conf
+sudo cp registries.conf /etc/containers/registries.conf
+
 # Start the local container registry
 registry/start
 
 # Setup the requirements and run the test pod
 kubectl apply -f cluster/rbac.yml -f cluster/secret.yml
+
+GOT=$(mktemp)
+EXPECTED=$(mktemp)
+CRIO_LOGS=$(mktemp)
+trap 'rm "$GOT" "$EXPECTED" "$CRIO_LOGS"' EXIT
+
+AUTH_PATH=/etc/crio/auth
+AUTH_PATH_IN_USE=$AUTH_PATH/in-use
+
+clear_journald() {
+    sudo journalctl --vacuum-time=1ms
+    sudo journalctl --rotate
+}
 
 run_test_pod() {
     kubectl delete -f cluster/pod.yml || true
@@ -16,27 +32,25 @@ run_test_pod() {
     kubectl wait --for=condition=ready pod/test-pod
 }
 
-# Run the first test pod, mirror should be found
-run_test_pod
+save_logs() {
+    # Save and clean the logs from the last credential provider run
+    LAST_PID=$(sudo journalctl -q -o cat --no-pager -n 1 --output-fields _PID _COMM=credential-prov)
+    sudo journalctl _PID="$LAST_PID" | sed -E 's;.*.go:[0-9]+:\s(.*);\1;' >"$GOT"
+}
 
-# Run the second test pod, mirrors should be empty
-echo "" | sudo tee /etc/containers/registries.conf
-run_test_pod
+testcase_mirror_found() {
+    clear_journald
+    run_test_pod
+    save_logs
 
-# Run the third test pod, mirror file does not exist
-sudo rm /etc/containers/registries.conf
-run_test_pod
+    NAMESPACE=default
+    IMAGE_HASH=7e59ad64326bc321517fb6fc6586de5ee149178394d9edfa2a877176cdf6fad5
+    AUTH_FILE=$AUTH_PATH/$NAMESPACE-$IMAGE_HASH.json
+    # AUTH_FILE_IN_USE has a UUID suffix, which we skip for validation
+    AUTH_FILE_IN_USE=$AUTH_PATH_IN_USE/$NAMESPACE-$IMAGE_HASH
 
-# Do assertions
-# TODO: Expand them when https://github.com/cri-o/cri-o/pull/9463 got merged
-GOT=$(mktemp)
-EXPECTED=$(mktemp)
-trap 'rm "$GOT" "$EXPECTED"' EXIT
-
-sudo journalctl _COMM=credential-prov --since "5 minutes ago" | sed -E 's;.*.go:[0-9]+:\s(.*);\1;' >"$GOT"
-
-# First test result
-cat >"$EXPECTED" <<EOL
+    # First test result: mirror should be found and written
+    cat >"$EXPECTED" <<EOL
 Running credential provider
 Reading from stdin
 Got stdin, parsing JSON as CredentialProviderRequest
@@ -44,18 +58,40 @@ Parsed credential provider request for image "docker.io/library/nginx"
 Parsing namespace from request
 Matching mirrors for registry config: /etc/containers/registries.conf
 Got mirror(s) for "docker.io/library/nginx": "localhost:5000"
-Getting secrets from namespace: default
+Getting secrets from namespace: $NAMESPACE
 Got 1 secret(s)
 Parsing secret: my-secret
 Found docker config JSON auth in secret "my-secret" for "http://localhost:5000"
 Checking if mirror "localhost:5000" matches registry "localhost:5000"
 Using mirror auth "localhost:5000" for registry from secret "localhost:5000"
-Wrote auth file to /etc/crio/auth/default-7e59ad64326bc321517fb6fc6586de5ee149178394d9edfa2a877176cdf6fad5.json with 1 number of entries
-Auth file path: /etc/crio/auth/default-7e59ad64326bc321517fb6fc6586de5ee149178394d9edfa2a877176cdf6fad5.json
+Wrote auth file to $AUTH_FILE with 1 number of entries
+Auth file path: $AUTH_FILE
 EOL
 
-# Second test result
-cat >>"$EXPECTED" <<EOL
+    diff "$GOT" "$EXPECTED"
+
+    # Assert CRI-O logs and auth file
+    # shellcheck disable=SC2024
+    sudo journalctl -u crio >"$CRIO_LOGS"
+    grep -q "Using auth file for namespace $NAMESPACE: $AUTH_FILE" "$CRIO_LOGS"
+    grep -q "Removed temp auth file: $AUTH_FILE_IN_USE" "$CRIO_LOGS"
+    [[ $(find "$AUTH_PATH" -type f) == "" ]]
+    test -d $AUTH_PATH_IN_USE
+    [[ $(find "$AUTH_PATH_IN_USE" -type f) == "" ]]
+
+    # Assert registry authorization
+    podman logs registry &>output
+    grep -q "authorized request" output
+}
+
+testcase_no_mirror_found() {
+    clear_journald
+    echo "" | sudo tee /etc/containers/registries.conf
+    run_test_pod
+    save_logs
+
+    # Second test result: No mirror should be found, auth file should not exist any more since CRI-O removed it.
+    cat >"$EXPECTED" <<EOL
 Running credential provider
 Reading from stdin
 Got stdin, parsing JSON as CredentialProviderRequest
@@ -65,15 +101,38 @@ Matching mirrors for registry config: /etc/containers/registries.conf
 No mirrors found, will not write any auth file
 EOL
 
-# Third test result
-cat >>"$EXPECTED" <<EOL
+    diff "$GOT" "$EXPECTED"
+
+    # Assert CRI-O logs and auth file
+    # shellcheck disable=SC2024
+    sudo journalctl -u crio >"$CRIO_LOGS"
+    grep -q "Looking for namespaced auth JSON file in:" "$CRIO_LOGS"
+    grep -vq "Using auth file for namespace default" "$CRIO_LOGS"
+    [[ $(find "$AUTH_PATH" -type f) == "" ]]
+}
+
+testcase_no_registries_conf_found() {
+    clear_journald
+    sudo rm /etc/containers/registries.conf
+    run_test_pod
+    save_logs
+
+    # Third test result: registries.conf does not exist, do nothing
+    cat >"$EXPECTED" <<EOL
 Running credential provider
 Registries conf path "/etc/containers/registries.conf" does not exist, stopping
 EOL
 
-diff "$GOT" "$EXPECTED"
+    diff "$GOT" "$EXPECTED"
 
-# Assert CRI-O logs
-sudo journalctl -u crio | grep -q "Using auth file for namespace default"
-podman logs registry &>output
-grep -q "authorized request" output
+    # Assert CRI-O logs and auth file
+    # shellcheck disable=SC2024
+    sudo journalctl -u crio >"$CRIO_LOGS"
+    grep -q "Looking for namespaced auth JSON file in:" "$CRIO_LOGS"
+    grep -vq "Using auth file for namespace default" "$CRIO_LOGS"
+}
+
+# Run all test cases
+testcase_mirror_found
+testcase_no_mirror_found
+testcase_no_registries_conf_found

--- a/test/e2e-setup
+++ b/test/e2e-setup
@@ -4,20 +4,34 @@ set -euox pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR"
 
+# Setup system for kubeadm usage
+swapoff -a
+sysctl -w net.ipv4.ip_forward=1
+
 # Install Kubernetes and CRI-O
 KUBERNETES_VERSION=v1.34
+curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --batch --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
 curl -fsSL https://download.opensuse.org/repositories/isv:/cri-o:/prerelease:/main/deb/Release.key | gpg --batch --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/cri-o:/prerelease:/main/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
 apt-get update
 apt-get install -y \
     cri-o \
+    jq \
     kubelet \
     kubeadm \
-    kubectl
+    kubectl \
+    podman \
+    net-tools
 
 # Setup CRI-O
 cp registries.conf /etc/containers/registries.conf
+printf '[crio.runtime]\nlog_level = "debug"' >/etc/crio/crio.conf.d/10-log-level.conf
+
+# Setup CNI to disable IPv6
+CNI_CONFIG=/etc/cni/net.d/10-crio-bridge.conflist
+jq 'del(.plugins[0].ipam.routes[1], .plugins[0].ipam.ranges[1])' $CNI_CONFIG.disabled >$CNI_CONFIG
+
 systemctl enable --now crio
 
 # Use the kubeadm default service account token audience
@@ -26,6 +40,7 @@ sed -i "s;kubernetes.default.svc;kubernetes.default.svc.cluster.local;g" "$CREDE
 
 # Setup cluster
 KUBEADM_CONFIG=$(mktemp)
+trap 'rm "$KUBEADM_CONFIG"' EXIT
 cat >"$KUBEADM_CONFIG" <<EOL
 ---
 apiVersion: kubeadm.k8s.io/v1beta4
@@ -36,6 +51,7 @@ localAPIEndpoint:
 nodeRegistration:
   name: 127.0.0.1
   criSocket: unix:///var/run/crio/crio.sock
+  imagePullSerial: false
   kubeletExtraArgs:
     - name: image-credential-provider-bin-dir
       value: $(dirname "$SCRIPT_DIR")/build
@@ -47,11 +63,10 @@ kind: KubeletConfiguration
 featureGates:
   KubeletServiceAccountTokenForCredentialProviders: true
 EOL
-swapoff -a
 kubeadm init --config="$KUBEADM_CONFIG"
 
 # Setup kubectl
-USER=runner
+USER=vagrant
 mkdir /home/$USER/.kube
 
 KUBECONFIG=/etc/kubernetes/admin.conf

--- a/test/vagrant-run
+++ b/test/vagrant-run
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$SCRIPT_DIR"
+
+exec vagrant ssh -- "bash -c 'cd /vagrant && $*'"


### PR DESCRIPTION
#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
- Use vagrant to be able to run the tests locally.
- Update the e2e tests and assert the auth files.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
