### PR TITLE
Make auth file writes atomic using write-rename pattern

### DIFF
--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -216,24 +216,48 @@ func writeAuthFile(dir, image, namespace string, fileContents docker.ConfigJSON)
 		return "", fmt.Errorf("get auth path: %w", err)
 	}
 
-	// Write directly to file using encoder to avoid intermediate buffer allocation
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	// Write to a temp file first, then atomically rename into place.
+	// This prevents a truncated or empty auth file if the process is
+	// killed mid-write.
+	tmpFile, err := os.CreateTemp(dir, ".auth-*.tmp")
 	if err != nil {
-		return "", fmt.Errorf("open auth file: %w", err)
+		return "", fmt.Errorf("create temp auth file: %w", err)
 	}
 
+	tmpPath := tmpFile.Name()
+
+	success := false
+
 	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			logger.L().Printf("Failed to close auth file: %v", closeErr)
+		if !success {
+			_ = os.Remove(tmpPath)
 		}
 	}()
 
-	encoder := json.NewEncoder(file)
+	encoder := json.NewEncoder(tmpFile)
 	encoder.SetIndent("", "\t")
 
 	if err := encoder.Encode(fileContents); err != nil {
+		_ = tmpFile.Close()
+
 		return "", fmt.Errorf("encode auth file: %w", err)
 	}
+
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+
+		return "", fmt.Errorf("sync temp auth file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return "", fmt.Errorf("close temp auth file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return "", fmt.Errorf("rename temp auth file: %w", err)
+	}
+
+	success = true
 
 	return path, nil
 }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Replaces `os.OpenFile` with `O_CREATE|O_TRUNC` in `writeAuthFile()` with a write-to-temp-then-rename pattern. If the process is killed mid-write (kubelet timeout, OOM, SIGKILL), the previous approach left a truncated or empty auth file on disk that CRI-O would then read. Now uses `os.CreateTemp` in the same directory followed by `os.Rename`, which is atomic on the same filesystem. A deferred cleanup removes the temp file on any error path.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

```release-note
None
```