### PR TITLE
Use godotenv.Read() to avoid mutating process env vars

### DIFF
--- a/internal/pkg/k8s/k8s.go
+++ b/internal/pkg/k8s/k8s.go
@@ -106,15 +106,26 @@ func APIServerHost(rootDir string) string {
 
 	envFilePath := filepath.Join(rootDir, defaultAPIServerEnvFile)
 
-	if err := godotenv.Load(envFilePath); os.IsNotExist(err) {
-		logger.L().Printf("Unable to find env file %q, using default API server host: %s", envFilePath, defaultHost)
+	envMap, err := godotenv.Read(envFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.L().Printf("Unable to find env file %q, using default API server host: %s", envFilePath, defaultHost)
+		} else {
+			logger.L().Printf("Unable to read env file %q, using default API server host: %s", envFilePath, defaultHost)
+		}
 
 		return defaultHost
 	}
 
-	// Avoid fmt.Sprintf allocation for simple string concatenation
-	serviceHost := os.Getenv("KUBERNETES_SERVICE_HOST")
-	servicePort := os.Getenv("KUBERNETES_SERVICE_PORT")
+	serviceHost := envMap["KUBERNETES_SERVICE_HOST"]
+	servicePort := envMap["KUBERNETES_SERVICE_PORT"]
+
+	if serviceHost == "" || servicePort == "" {
+		logger.L().Printf("Env file %q missing KUBERNETES_SERVICE_HOST or KUBERNETES_SERVICE_PORT, using default API server host: %s", envFilePath, defaultHost)
+
+		return defaultHost
+	}
+
 	host := serviceHost + ":" + servicePort
 	logger.L().Printf("Using API server host: %s", host)
 

--- a/internal/pkg/k8s/k8s_test.go
+++ b/internal/pkg/k8s/k8s_test.go
@@ -212,9 +212,9 @@ func TestRetrieveSecrets(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // Test manipulates global env vars and cannot run in parallel
 func TestAPIServerHost(t *testing.T) {
-	//nolint:paralleltest // Subtests manipulate global env vars and cannot run in parallel
+	t.Parallel()
+
 	for name, tc := range map[string]struct {
 		rootDir      string
 		setupEnvFile bool
@@ -242,48 +242,27 @@ func TestAPIServerHost(t *testing.T) {
 			setupEnvFile: false,
 			expected:     "localhost:6443",
 		},
-		"empty env file returns colon only": {
+		"empty env file returns default": {
 			rootDir:      t.TempDir(),
 			setupEnvFile: true,
 			envContent:   "",
-			expected:     ":",
+			expected:     "localhost:6443",
 		},
-		"partial env vars host only": {
+		"partial env vars host only returns default": {
 			rootDir:      t.TempDir(),
 			setupEnvFile: true,
 			envContent:   "KUBERNETES_SERVICE_HOST=partial.host",
-			expected:     "partial.host:",
+			expected:     "localhost:6443",
 		},
-		"partial env vars port only": {
+		"partial env vars port only returns default": {
 			rootDir:      t.TempDir(),
 			setupEnvFile: true,
 			envContent:   "KUBERNETES_SERVICE_PORT=9443",
-			expected:     ":9443",
+			expected:     "localhost:6443",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			// Note: Not running subtests in parallel due to global env var manipulation
-
-			// Save and clear env vars for clean test
-			originalHost := os.Getenv("KUBERNETES_SERVICE_HOST")
-			originalPort := os.Getenv("KUBERNETES_SERVICE_PORT")
-
-			t.Cleanup(func() {
-				if originalHost != "" {
-					require.NoError(t, os.Setenv("KUBERNETES_SERVICE_HOST", originalHost)) //nolint:usetesting // Conditional restore
-				} else {
-					require.NoError(t, os.Unsetenv("KUBERNETES_SERVICE_HOST"))
-				}
-
-				if originalPort != "" {
-					require.NoError(t, os.Setenv("KUBERNETES_SERVICE_PORT", originalPort)) //nolint:usetesting // Conditional restore
-				} else {
-					require.NoError(t, os.Unsetenv("KUBERNETES_SERVICE_PORT"))
-				}
-			})
-
-			require.NoError(t, os.Unsetenv("KUBERNETES_SERVICE_HOST"))
-			require.NoError(t, os.Unsetenv("KUBERNETES_SERVICE_PORT"))
+			t.Parallel()
 
 			if tc.setupEnvFile {
 				envFilePath := filepath.Join(tc.rootDir, "apiserver-url.env")


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Replaces `godotenv.Load()` with `godotenv.Read()` in `APIServerHost()` to read env file values from a returned map instead of calling `os.Setenv()` internally. This removes global state mutation and allows `TestAPIServerHost` to run in parallel.

Also validates that both `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` are non-empty, falling back to the default `localhost:6443` otherwise. Previously, partial or empty env files produced invalid host strings like `":"` or `"host:"`. Logs a message on any env file read error, not just file-not-found.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

```release-note
None
```