### PR TITLE
Validate both env vars in APIServerHost before building host string

### DIFF
--- a/internal/pkg/k8s/k8s.go
+++ b/internal/pkg/k8s/k8s.go
@@ -115,6 +115,13 @@ func APIServerHost(rootDir string) string {
 	// Avoid fmt.Sprintf allocation for simple string concatenation
 	serviceHost := os.Getenv("KUBERNETES_SERVICE_HOST")
 	servicePort := os.Getenv("KUBERNETES_SERVICE_PORT")
+
+	if serviceHost == "" || servicePort == "" {
+		logger.L().Printf("Env file %q missing KUBERNETES_SERVICE_HOST or KUBERNETES_SERVICE_PORT, using default API server host: %s", envFilePath, defaultHost)
+
+		return defaultHost
+	}
+
 	host := serviceHost + ":" + servicePort
 	logger.L().Printf("Using API server host: %s", host)
 

--- a/internal/pkg/k8s/k8s_test.go
+++ b/internal/pkg/k8s/k8s_test.go
@@ -242,23 +242,23 @@ func TestAPIServerHost(t *testing.T) {
 			setupEnvFile: false,
 			expected:     "localhost:6443",
 		},
-		"empty env file returns colon only": {
+		"empty env file returns default": {
 			rootDir:      t.TempDir(),
 			setupEnvFile: true,
 			envContent:   "",
-			expected:     ":",
+			expected:     "localhost:6443",
 		},
-		"partial env vars host only": {
+		"partial env vars host only returns default": {
 			rootDir:      t.TempDir(),
 			setupEnvFile: true,
 			envContent:   "KUBERNETES_SERVICE_HOST=partial.host",
-			expected:     "partial.host:",
+			expected:     "localhost:6443",
 		},
-		"partial env vars port only": {
+		"partial env vars port only returns default": {
 			rootDir:      t.TempDir(),
 			setupEnvFile: true,
 			envContent:   "KUBERNETES_SERVICE_PORT=9443",
-			expected:     ":9443",
+			expected:     "localhost:6443",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
`APIServerHost()` returned invalid strings like `":"`, `"host:"`, or `":port"` when the env file existed but was empty or partially populated. Now validates that both `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` are non-empty, falling back to `localhost:6443` otherwise.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
This fix is also included in the more comprehensive `fix/godotenv-read` PR. This branch is a smaller, standalone alternative that does not change the env-reading approach.

```release-note
None
```